### PR TITLE
gtest.rb: use gtests internal tuple library

### DIFF
--- a/gtest.rb
+++ b/gtest.rb
@@ -6,6 +6,7 @@ class Gtest <Formula
   md5 '7e27f5f3b79dd1ce9092e159cdbd0635'
 
   def install
+    ENV.append 'CXXFLAGS', '-DGTEST_USE_OWN_TR1_TUPLE=1'
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make install"
   end


### PR DESCRIPTION
Force gtest to use its internal tuple library.

Fixes build error: 
"./include/gtest/internal/gtest-port.h:449:10: fatal error: 'tr1/tuple' file not found
# include <tr1/tuple>  // NOLINT"
